### PR TITLE
Add Google OAuth sign-up with member verification

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,7 +5,8 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID="your-walletconnect-project-id"
 NEXT_PUBLIC_SUPABASE_URL="https://your-project-id.supabase.co"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key"
 
-# Supabase service role (for member verification)
+# Supabase service role — REQUIRED for Google sign-up member verification
+# Get it from: Supabase Dashboard > Settings > API > service_role (secret)
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 
 # AI enrichment (server-side only)

--- a/src/app/api/members/pending/route.ts
+++ b/src/app/api/members/pending/route.ts
@@ -1,16 +1,13 @@
 import { NextResponse } from "next/server";
 import { createSupabaseServiceClient } from "@/lib/supabase/service-client";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export async function GET() {
+  // Use service client if available (bypasses RLS), otherwise fall back to server client
   const serviceClient = createSupabaseServiceClient();
-  if (!serviceClient) {
-    return NextResponse.json(
-      { error: "Service client not configured" },
-      { status: 500 }
-    );
-  }
+  const dbClient = serviceClient ?? (await createSupabaseServerClient());
 
-  const { data, error } = await serviceClient
+  const { data, error } = await dbClient
     .from("profiles")
     .select("id, display_name, email, avatar_url, auth_method, created_at")
     .eq("is_verified", false)
@@ -18,8 +15,11 @@ export async function GET() {
     .order("created_at", { ascending: false });
 
   if (error) {
-    console.error("Error fetching pending members:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[pending] Error fetching pending members:", error.message);
+    return NextResponse.json(
+      { error: error.message, hint: "Check that the profiles table has auth_method and is_verified columns" },
+      { status: 500 }
+    );
   }
 
   return NextResponse.json(data || []);

--- a/src/app/api/members/reject/route.ts
+++ b/src/app/api/members/reject/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServiceClient } from "@/lib/supabase/service-client";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function POST(request: Request) {
+  let body: { userId?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { userId: targetUserId } = body;
+
+  if (!targetUserId) {
+    return NextResponse.json({ error: "userId is required" }, { status: 400 });
+  }
+
+  // Verify the caller is authenticated
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const serviceClient = createSupabaseServiceClient();
+
+  if (!serviceClient) {
+    return NextResponse.json(
+      { error: "Server configuration error: service role key not set." },
+      { status: 500 }
+    );
+  }
+
+  // Delete the pending profile (and their Supabase auth user)
+  const { error: deleteError } = await serviceClient
+    .from("profiles")
+    .delete()
+    .eq("id", targetUserId)
+    .eq("is_verified", false);
+
+  if (deleteError) {
+    console.error("[reject] Error deleting profile:", deleteError.message);
+    return NextResponse.json({ error: deleteError.message }, { status: 500 });
+  }
+
+  // Also remove the Supabase auth user so they can sign up again if needed
+  const { error: authDeleteError } = await serviceClient.auth.admin.deleteUser(targetUserId);
+
+  if (authDeleteError) {
+    console.error("[reject] Error deleting auth user:", authDeleteError.message);
+    // Profile is already deleted, so this is non-critical
+  }
+
+  console.log(`[reject] Rejected and removed user ${targetUserId}`);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/members/verify/route.ts
+++ b/src/app/api/members/verify/route.ts
@@ -3,38 +3,74 @@ import { createSupabaseServiceClient } from "@/lib/supabase/service-client";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export async function POST(request: Request) {
-  const serviceClient = createSupabaseServiceClient();
-  if (!serviceClient) {
-    return NextResponse.json(
-      { error: "Service client not configured" },
-      { status: 500 }
-    );
+  // Parse the request
+  let body: { userId?: string; verifierId?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  // Get the requesting user (must be an existing verified member)
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  // Parse the request
-  const { userId: targetUserId, verifierId } = await request.json();
+  const { userId: targetUserId, verifierId } = body;
 
   if (!targetUserId) {
     return NextResponse.json({ error: "userId is required" }, { status: 400 });
   }
 
-  // The verifierId can come from either a Supabase auth user or a wallet address
-  // For wallet users verifying, the verifierId is their wallet address
-  // For Google users verifying, the verifierId is their Supabase user ID
+  // Get the requesting user's identity
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
   const actualVerifierId = user?.id || verifierId;
 
   if (!actualVerifierId) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  // Use service client to bypass RLS and update the profile
-  const { error } = await serviceClient
+  // Use service client to bypass RLS (needed because the update policy
+  // only allows users to update their own profile)
+  const serviceClient = createSupabaseServiceClient();
+
+  if (!serviceClient) {
+    console.error(
+      "[verify] SUPABASE_SERVICE_ROLE_KEY is not configured. " +
+      "Member verification requires the service role key to bypass RLS. " +
+      "Set SUPABASE_SERVICE_ROLE_KEY in your .env file."
+    );
+    return NextResponse.json(
+      {
+        error:
+          "Server configuration error: service role key not set. " +
+          "Ask your admin to set SUPABASE_SERVICE_ROLE_KEY.",
+      },
+      { status: 500 }
+    );
+  }
+
+  // Verify the target user exists and is pending
+  const { data: target, error: targetError } = await serviceClient
+    .from("profiles")
+    .select("id, is_verified, auth_method")
+    .eq("id", targetUserId)
+    .maybeSingle();
+
+  if (targetError) {
+    console.error("[verify] Error fetching target profile:", targetError.message);
+    return NextResponse.json({ error: targetError.message }, { status: 500 });
+  }
+
+  if (!target) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  if (target.is_verified) {
+    return NextResponse.json({ error: "User is already verified" }, { status: 400 });
+  }
+
+  // Perform the verification
+  const { error: updateError } = await serviceClient
     .from("profiles")
     .update({
       is_verified: true,
@@ -44,10 +80,11 @@ export async function POST(request: Request) {
     })
     .eq("id", targetUserId);
 
-  if (error) {
-    console.error("Error verifying member:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  if (updateError) {
+    console.error("[verify] Error updating profile:", updateError.message);
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
   }
 
+  console.log(`[verify] User ${targetUserId} verified by ${actualVerifierId}`);
   return NextResponse.json({ success: true });
 }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createSupabaseServiceClient } from "@/lib/supabase/service-client";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
 
   if (!code) {
+    console.error("[auth/callback] No code parameter");
     return NextResponse.redirect(new URL("/", request.url));
   }
 
@@ -14,7 +16,7 @@ export async function GET(request: Request) {
   const { error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {
-    console.error("Error exchanging code for session", error.message);
+    console.error("[auth/callback] Error exchanging code for session:", error.message);
     return NextResponse.redirect(new URL("/", request.url));
   }
 
@@ -24,31 +26,74 @@ export async function GET(request: Request) {
   } = await supabase.auth.getUser();
 
   if (userError || !user) {
+    console.error("[auth/callback] Error getting user:", userError?.message);
     return NextResponse.redirect(new URL("/", request.url));
   }
 
-  // Check if profile already exists
-  const { data: existingProfile } = await supabase
+  // Use service client to bypass RLS for profile operations.
+  // Falls back to server client if service key isn't configured.
+  const dbClient = createSupabaseServiceClient() ?? supabase;
+
+  // 1. Check if there's already a profile keyed by this Supabase user ID
+  //    (returning Google user who already has a Google-created profile)
+  const { data: profileById, error: selectError } = await dbClient
     .from("profiles")
     .select("id, is_verified")
     .eq("id", user.id)
     .maybeSingle();
 
-  if (existingProfile) {
-    // Profile exists - redirect based on verification status
-    if (existingProfile.is_verified) {
+  if (selectError) {
+    console.error("[auth/callback] Error checking profile by ID:", selectError.message);
+  }
+
+  if (profileById) {
+    if (profileById.is_verified) {
       return NextResponse.redirect(new URL("/dashboard", request.url));
     }
     return NextResponse.redirect(new URL("/pending", request.url));
   }
 
-  // Create new profile for Google user
+  // 2. Check if there's an existing profile with the same email
+  //    (wallet user who already has a profile — link the accounts)
+  if (user.email) {
+    const { data: profileByEmail, error: emailError } = await dbClient
+      .from("profiles")
+      .select("id, is_verified, email")
+      .eq("email", user.email)
+      .maybeSingle();
+
+    if (emailError) {
+      console.error("[auth/callback] Error checking profile by email:", emailError.message);
+    }
+
+    if (profileByEmail) {
+      // Link: store the Supabase user ID on the existing profile so the
+      // auth context can find it later
+      const { error: linkError } = await dbClient
+        .from("profiles")
+        .update({ google_user_id: user.id })
+        .eq("id", profileByEmail.id);
+
+      if (linkError) {
+        console.error("[auth/callback] Error linking Google to existing profile:", linkError.message);
+      } else {
+        console.log(
+          `[auth/callback] Linked Google user ${user.id} to existing profile ${profileByEmail.id}`
+        );
+      }
+
+      // Existing member — go straight to dashboard
+      return NextResponse.redirect(new URL("/dashboard", request.url));
+    }
+  }
+
+  // 3. No existing profile — create a new one for this Google user
   const email = user.email;
   const displayName =
     user.user_metadata?.full_name || user.user_metadata?.name || null;
   const avatarUrl = user.user_metadata?.avatar_url || null;
 
-  await supabase.from("profiles").upsert(
+  const { error: upsertError } = await dbClient.from("profiles").upsert(
     {
       id: user.id,
       email,
@@ -60,6 +105,9 @@ export async function GET(request: Request) {
     { onConflict: "id" }
   );
 
-  // New Google user goes to pending verification
+  if (upsertError) {
+    console.error("[auth/callback] Error creating profile:", upsertError.message);
+  }
+
   return NextResponse.redirect(new URL("/pending", request.url));
 }

--- a/src/app/dashboard/directory/directory-content.tsx
+++ b/src/app/dashboard/directory/directory-content.tsx
@@ -8,7 +8,7 @@ import type { Profile } from "@/lib/supabase/types";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Check, ChevronDown, ChevronUp, Loader2, UserCheck } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, Loader2, UserCheck, X } from "lucide-react";
 
 const supabase = createSupabaseBrowserClient();
 
@@ -37,6 +37,7 @@ export function DirectoryContent({ isPublic = false }: DirectoryContentProps) {
   const [pendingLoading, setPendingLoading] = useState(false);
   const [pendingCount, setPendingCount] = useState(0);
   const [verifying, setVerifying] = useState<string | null>(null);
+  const [rejecting, setRejecting] = useState<string | null>(null);
 
   // Fetch profiles for all members
   useEffect(() => {
@@ -65,36 +66,38 @@ export function DirectoryContent({ isPublic = false }: DirectoryContentProps) {
     fetchProfiles();
   }, [members]);
 
-  // Fetch pending member count on mount (for authenticated members)
+  // Fetch pending members on mount and when expanded (for authenticated members)
   useEffect(() => {
     if (isPublic || !isMember) return;
 
-    supabase
-      .from("profiles")
-      .select("id", { count: "exact", head: true })
-      .eq("is_verified", false)
-      .eq("auth_method", "google")
-      .then(({ count }) => {
-        setPendingCount(count ?? 0);
-      });
-  }, [isPublic, isMember]);
-
-  // Fetch full pending list when expanded
-  useEffect(() => {
-    if (!showPending) return;
-
-    setPendingLoading(true);
-    supabase
-      .from("profiles")
-      .select("id, display_name, email, avatar_url, auth_method, created_at")
-      .eq("is_verified", false)
-      .eq("auth_method", "google")
-      .order("created_at", { ascending: false })
-      .then(({ data }) => {
-        setPending(data ?? []);
+    // Always fetch the full list via the API route (uses service client to bypass RLS)
+    const fetchPending = async () => {
+      setPendingLoading(true);
+      try {
+        const res = await fetch("/api/members/pending");
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          console.error("[directory] Error fetching pending members:", err);
+          setPending([]);
+          setPendingCount(0);
+          setPendingLoading(false);
+          return;
+        }
+        const data = await res.json();
+        const list = Array.isArray(data) ? data : [];
+        setPending(list);
+        setPendingCount(list.length);
+      } catch (err) {
+        console.error("[directory] Error fetching pending members:", err);
+        setPending([]);
+        setPendingCount(0);
+      } finally {
         setPendingLoading(false);
-      });
-  }, [showPending]);
+      }
+    };
+
+    fetchPending();
+  }, [isPublic, isMember]);
 
   const handleVerify = async (memberId: string) => {
     setVerifying(memberId);
@@ -120,6 +123,32 @@ export function DirectoryContent({ isPublic = false }: DirectoryContentProps) {
       alert("Failed to verify member");
     } finally {
       setVerifying(null);
+    }
+  };
+
+  const handleReject = async (memberId: string) => {
+    if (!confirm("Reject this sign-up? Their account will be removed.")) return;
+
+    setRejecting(memberId);
+    try {
+      const res = await fetch("/api/members/reject", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: memberId }),
+      });
+
+      if (res.ok) {
+        setPending((prev) => prev.filter((m) => m.id !== memberId));
+        setPendingCount((c) => Math.max(0, c - 1));
+      } else {
+        const data = await res.json();
+        alert(data.error || "Failed to reject member");
+      }
+    } catch (err) {
+      console.error("Error rejecting member:", err);
+      alert("Failed to reject member");
+    } finally {
+      setRejecting(null);
     }
   };
 
@@ -273,55 +302,69 @@ export function DirectoryContent({ isPublic = false }: DirectoryContentProps) {
       )}
 
       {/* Verify pending members section */}
-      {!isPublic && isMember && pendingCount > 0 && (
+      {!isPublic && isMember && (
         <div className="mt-2">
           <button
             onClick={() => setShowPending(!showPending)}
             className="inline-flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
             <UserCheck className="h-3.5 w-3.5" />
-            {pendingCount} pending verification{pendingCount !== 1 ? "s" : ""}
-            {showPending ? (
-              <ChevronUp className="h-3 w-3" />
-            ) : (
-              <ChevronDown className="h-3 w-3" />
-            )}
+            {pendingLoading
+              ? "Checking pending..."
+              : pendingCount > 0
+                ? `${pendingCount} pending verification${pendingCount !== 1 ? "s" : ""}`
+                : "No pending verifications"}
+            {pendingCount > 0 &&
+              (showPending ? (
+                <ChevronUp className="h-3 w-3" />
+              ) : (
+                <ChevronDown className="h-3 w-3" />
+              ))}
           </button>
 
-          {showPending && (
+          {showPending && pendingCount > 0 && (
             <div className="mt-3 space-y-2">
-              {pendingLoading ? (
-                <div className="flex items-center justify-center py-6">
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                </div>
-              ) : (
-                pending.map((member) => (
-                  <Card key={member.id}>
-                    <CardContent className="flex items-center justify-between gap-4 py-3">
-                      <div className="flex items-center gap-3 min-w-0">
-                        <Avatar className="h-9 w-9 shrink-0">
-                          <AvatarImage
-                            src={member.avatar_url || undefined}
-                            alt={member.display_name || ""}
-                          />
-                          <AvatarFallback className="text-xs">
-                            {getPendingInitials(member)}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="min-w-0">
-                          <p className="font-medium text-sm truncate">
-                            {member.display_name || "No name"}
-                          </p>
-                          <p className="text-xs text-muted-foreground truncate">
-                            {member.email}
-                          </p>
-                        </div>
+              {pending.map((member) => (
+                <Card key={member.id}>
+                  <CardContent className="flex items-center justify-between gap-4 py-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <Avatar className="h-9 w-9 shrink-0">
+                        <AvatarImage
+                          src={member.avatar_url || undefined}
+                          alt={member.display_name || ""}
+                        />
+                        <AvatarFallback className="text-xs">
+                          {getPendingInitials(member)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0">
+                        <p className="font-medium text-sm truncate">
+                          {member.display_name || "No name"}
+                        </p>
+                        <p className="text-xs text-muted-foreground truncate">
+                          {member.email}
+                        </p>
                       </div>
+                    </div>
+                    <div className="flex gap-1.5 shrink-0">
+                      <Button
+                        onClick={() => handleReject(member.id)}
+                        disabled={rejecting === member.id || verifying === member.id}
+                        size="sm"
+                        variant="outline"
+                        className="gap-1 text-muted-foreground hover:text-red-500 hover:border-red-500/50"
+                      >
+                        {rejecting === member.id ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <X className="h-3.5 w-3.5" />
+                        )}
+                      </Button>
                       <Button
                         onClick={() => handleVerify(member.id)}
-                        disabled={verifying === member.id}
+                        disabled={verifying === member.id || rejecting === member.id}
                         size="sm"
-                        className="shrink-0 gap-1.5"
+                        className="gap-1.5"
                       >
                         {verifying === member.id ? (
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -330,10 +373,10 @@ export function DirectoryContent({ isPublic = false }: DirectoryContentProps) {
                         )}
                         Verify
                       </Button>
-                    </CardContent>
-                  </Card>
-                ))
-              )}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
             </div>
           )}
         </div>

--- a/src/app/dashboard/profile/profile-content.tsx
+++ b/src/app/dashboard/profile/profile-content.tsx
@@ -19,7 +19,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import Link from "next/link";
 
 export function ProfileContent() {
-  const { userId, authMethod, walletAddress, email, isWalletConnected } = useAuth();
+  const { userId, authMethod, walletAddress, email, isWalletConnected, linkWallet, profile: authProfile } = useAuth();
   const { tokenId, tokenURI } = useMembership();
   const { totalSupply } = useAllMembers();
 
@@ -27,6 +27,16 @@ export function ProfileContent() {
   const [isLoading, setIsLoading] = useState(true);
   const [displayName, setDisplayName] = useState("");
   const [bio, setBio] = useState("");
+
+  // When a Google user connects a wallet, save the address to their profile
+  useEffect(() => {
+    if (authMethod === "google" && isWalletConnected && walletAddress) {
+      // Only link if not already saved
+      if (authProfile?.wallet_address !== walletAddress) {
+        linkWallet(walletAddress);
+      }
+    }
+  }, [authMethod, isWalletConnected, walletAddress, authProfile?.wallet_address, linkWallet]);
   const [isSaving, setIsSaving] = useState(false);
   const [isSavingBio, setIsSavingBio] = useState(false);
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
@@ -302,7 +312,7 @@ export function ProfileContent() {
         </Card>
       )}
 
-      {authMethod === "google" && !isWalletConnected && (
+      {authMethod === "google" && !isWalletConnected && !authProfile?.wallet_address && (
         <Card>
           <CardHeader>
             <CardTitle className="text-base font-semibold">

--- a/src/lib/auth/context.tsx
+++ b/src/lib/auth/context.tsx
@@ -2,6 +2,7 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useState,
@@ -23,8 +24,8 @@ interface AuthState {
   isLoading: boolean;
 
   // Membership / verification
-  isMember: boolean; // wallet NFT holder OR verified Google user
-  isPendingVerification: boolean; // Google user awaiting approval
+  isMember: boolean;
+  isPendingVerification: boolean;
 
   // Profile
   profile: Profile | null;
@@ -41,6 +42,7 @@ interface AuthState {
 
   // Actions
   signOut: () => Promise<void>;
+  linkWallet: (address: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthState | null>(null);
@@ -66,6 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [supabaseUser, setSupabaseUser] = useState<User | null>(null);
   const [supabaseLoading, setSupabaseLoading] = useState(true);
   const [profile, setProfile] = useState<Profile | null>(null);
+  const [profileLoading, setProfileLoading] = useState(false);
 
   // Listen for Supabase auth state
   useEffect(() => {
@@ -84,54 +87,158 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription.unsubscribe();
   }, []);
 
-  // Determine auth method
-  const authMethod: AuthMethod =
-    isConnected && address
+  // Determine auth method.
+  // If a Supabase (Google) session exists, that's the primary auth — even if
+  // a wallet is also connected. This prevents flipping to "wallet" mode when
+  // a Google user connects their wallet on the profile page.
+  const authMethod: AuthMethod = supabaseUser
+    ? "google"
+    : isConnected && address
       ? "wallet"
-      : supabaseUser
-        ? "google"
-        : null;
+      : null;
 
-  const userId =
+  // For wallet-only users, userId = wallet address.
+  // For Google users (even if wallet is also connected), userId is resolved
+  // after profile lookup (could be Supabase UUID or linked wallet address).
+  const rawUserId =
     authMethod === "wallet" ? address! : supabaseUser?.id ?? null;
 
-  const isLoading: boolean =
-    isReconnecting || supabaseLoading || (authMethod === "wallet" && !!isMembershipLoading);
+  // The effective userId is the profile's ID (which may differ from rawUserId
+  // for linked accounts where profile.id = wallet address).
+  const userId = profile?.id ?? rawUserId;
 
   // Fetch profile for authenticated user
   useEffect(() => {
-    if (!userId) {
+    if (!rawUserId) {
       setProfile(null);
       return;
     }
 
-    supabase
-      .from("profiles")
-      .select("*")
-      .eq("id", userId)
-      .maybeSingle()
-      .then(({ data }) => {
-        setProfile(data);
-      });
-  }, [userId]);
+    setProfileLoading(true);
 
-  const refreshProfile = async () => {
+    const fetchProfile = async () => {
+      // 1. Try direct lookup by ID
+      const { data: byId, error: idError } = await supabase
+        .from("profiles")
+        .select("*")
+        .eq("id", rawUserId)
+        .maybeSingle();
+
+      if (idError) {
+        console.error("[AuthProvider] Error fetching profile by ID:", idError.message);
+      }
+
+      if (byId) {
+        setProfile(byId);
+        setProfileLoading(false);
+        return;
+      }
+
+      // 2. For Google users: look up by google_user_id (linked wallet profile)
+      if (authMethod === "google" && supabaseUser) {
+        const { data: byGoogleId, error: googleError } = await supabase
+          .from("profiles")
+          .select("*")
+          .eq("google_user_id", supabaseUser.id)
+          .maybeSingle();
+
+        if (googleError) {
+          console.error("[AuthProvider] Error fetching profile by google_user_id:", googleError.message);
+        }
+
+        if (byGoogleId) {
+          setProfile(byGoogleId);
+          setProfileLoading(false);
+          return;
+        }
+
+        // 3. Fallback: look up by email
+        if (supabaseUser.email) {
+          const { data: byEmail, error: emailError } = await supabase
+            .from("profiles")
+            .select("*")
+            .eq("email", supabaseUser.email)
+            .maybeSingle();
+
+          if (emailError) {
+            console.error("[AuthProvider] Error fetching profile by email:", emailError.message);
+          }
+
+          if (byEmail) {
+            setProfile(byEmail);
+            setProfileLoading(false);
+            return;
+          }
+        }
+
+        // 4. No profile found at all — create one as fallback
+        console.log("[AuthProvider] No profile found for Google user, creating one...");
+
+        const displayName =
+          supabaseUser.user_metadata?.full_name ||
+          supabaseUser.user_metadata?.name ||
+          null;
+        const avatarUrl = supabaseUser.user_metadata?.avatar_url || null;
+
+        const { data: newProfile, error: insertError } = await supabase
+          .from("profiles")
+          .upsert(
+            {
+              id: supabaseUser.id,
+              email: supabaseUser.email,
+              display_name: displayName,
+              avatar_url: avatarUrl,
+              auth_method: "google",
+              is_verified: false,
+            },
+            { onConflict: "id" }
+          )
+          .select()
+          .single();
+
+        if (insertError) {
+          console.error("[AuthProvider] Error creating profile:", insertError.message);
+        }
+
+        setProfile(newProfile ?? null);
+      }
+
+      setProfileLoading(false);
+    };
+
+    fetchProfile();
+  }, [rawUserId, authMethod, supabaseUser]);
+
+  const refreshProfile = useCallback(async () => {
     if (!userId) return;
+    // Refresh using the profile's actual ID (handles linked accounts)
     const { data } = await supabase
       .from("profiles")
       .select("*")
       .eq("id", userId)
       .maybeSingle();
     setProfile(data);
-  };
+  }, [userId]);
 
-  // Membership: either NFT member or verified Google user
+  const isLoading: boolean =
+    isReconnecting ||
+    supabaseLoading ||
+    profileLoading ||
+    (authMethod === "wallet" && !!isMembershipLoading);
+
+  // Membership: NFT holder, verified Google user, or linked wallet user
+  // A linked account (Google user with existing wallet profile) is always a member
+  // because they were already a wallet member.
+  const isLinkedAccount =
+    authMethod === "google" && profile !== null && profile.id !== supabaseUser?.id;
+
   const isMember =
     (authMethod === "wallet" && isNftMember) ||
-    (authMethod === "google" && profile?.is_verified === true);
+    (authMethod === "google" && profile?.is_verified === true) ||
+    isLinkedAccount;
 
   const isPendingVerification =
-    authMethod === "google" && profile !== null && !profile.is_verified;
+    authMethod === "google" && !isLoading && !isMember;
 
   const isAuthenticated = authMethod !== null;
 
@@ -139,8 +246,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (supabaseUser) {
       await supabase.auth.signOut();
     }
-    // Wallet disconnect is handled by wagmi's disconnect
   };
+
+  // Save a wallet address to the current profile
+  const linkWallet = useCallback(
+    async (walletAddr: string) => {
+      if (!userId) return;
+      const { error } = await supabase
+        .from("profiles")
+        .update({
+          wallet_address: walletAddr,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", userId);
+
+      if (error) {
+        console.error("[AuthProvider] Error linking wallet:", error.message);
+        return;
+      }
+
+      // Refresh profile to pick up the change
+      await refreshProfile();
+    },
+    [userId, refreshProfile]
+  );
 
   const value: AuthState = {
     userId,
@@ -157,6 +286,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     supabaseUser,
     email: supabaseUser?.email ?? profile?.email ?? null,
     signOut,
+    linkWallet,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -25,6 +25,7 @@ export interface Profile {
   is_verified: boolean;
   verified_by: string | null;
   verified_at: string | null;
+  google_user_id?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/add_google_auth.sql
+++ b/supabase/migrations/add_google_auth.sql
@@ -1,17 +1,39 @@
 -- Add Google auth support to profiles
+-- Run this migration against your Supabase database to enable Google sign-up
+
+-- Add new columns (safe to re-run — uses IF NOT EXISTS)
 ALTER TABLE public.profiles
   ADD COLUMN IF NOT EXISTS wallet_address text,
   ADD COLUMN IF NOT EXISTS email text,
   ADD COLUMN IF NOT EXISTS auth_method text DEFAULT 'wallet' CHECK (auth_method IN ('wallet', 'google')),
   ADD COLUMN IF NOT EXISTS is_verified boolean DEFAULT false,
-  ADD COLUMN IF NOT EXISTS verified_by uuid REFERENCES public.profiles(id),
-  ADD COLUMN IF NOT EXISTS verified_at timestamptz;
+  ADD COLUMN IF NOT EXISTS verified_by text,
+  ADD COLUMN IF NOT EXISTS verified_at timestamptz,
+  ADD COLUMN IF NOT EXISTS google_user_id text;
 
 -- Existing wallet-based profiles are automatically verified
 UPDATE public.profiles SET is_verified = true WHERE auth_method = 'wallet' OR auth_method IS NULL;
 
--- Allow anon users to read profiles (for pending verification page)
--- Already exists: "Profiles are viewable by everyone"
+-- Index for looking up profiles by google_user_id (linked accounts)
+CREATE INDEX IF NOT EXISTS idx_profiles_google_user_id ON public.profiles (google_user_id) WHERE google_user_id IS NOT NULL;
 
--- Allow service role to update verification status
--- (handled by service client, bypasses RLS)
+-- Index for looking up profiles by email
+CREATE INDEX IF NOT EXISTS idx_profiles_email ON public.profiles (email) WHERE email IS NOT NULL;
+
+-- Ensure the "Profiles are viewable by everyone" policy exists
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'profiles' AND policyname = 'Profiles are viewable by everyone'
+  ) THEN
+    CREATE POLICY "Profiles are viewable by everyone"
+      ON public.profiles
+      FOR SELECT
+      USING (true);
+  END IF;
+END
+$$;
+
+-- IMPORTANT: Member verification requires SUPABASE_SERVICE_ROLE_KEY to be set in your .env
+-- The service client bypasses RLS to allow one member to update another member's is_verified field.
+-- Get your service role key from: Supabase Dashboard > Settings > API > service_role (secret)


### PR DESCRIPTION
## Summary
- Adds Google sign-in via Supabase OAuth as an alternative to wallet-based auth, lowering the barrier to community participation
- New Google users are placed in a pending state until an existing verified member approves them from the Members management page
- Wallet connection remains fully available — users can still connect a wallet at any time for NFT-based membership
- Introduces a unified `AuthProvider` context that handles both wallet and Google auth methods across the app
- Includes DB schema migration adding `auth_method`, `email`, `is_verified`, and `avatar_url` columns to profiles

## Test plan
- [ ] Configure Google as an OAuth provider in Supabase dashboard
- [ ] Test signing in with Google — should land on `/pending` page
- [ ] Test that a verified member can approve pending users from `/dashboard/members`
- [ ] Verify wallet-based auth still works as before
- [ ] Confirm approved Google users can access the full dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)