### PR TITLE
Fix ICS calendar: add VTIMEZONE, CRLF line endings, and refresh hints

### DIFF
--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -24,6 +24,26 @@ CALSCALE:GREGORIAN
 METHOD:PUBLISH
 X-WR-CALNAME:N3Q Events
 X-WR-TIMEZONE:${TIMEZONE}
+REFRESH-INTERVAL;VALUE=DURATION:PT1H
+X-PUBLISHED-TTL:PT1H
+BEGIN:VTIMEZONE
+TZID:${TIMEZONE}
+X-LIC-LOCATION:${TIMEZONE}
+BEGIN:STANDARD
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+END:DAYLIGHT
+END:VTIMEZONE
 `;
 
   for (const event of events) {
@@ -108,7 +128,8 @@ DTEND;VALUE=DATE:${dtend}
 
   ics += `END:VCALENDAR`;
 
-  return ics;
+  // RFC 5545 requires CRLF line endings
+  return ics.replace(/\r?\n/g, "\r\n");
 }
 
 export async function GET() {
@@ -134,8 +155,7 @@ export async function GET() {
       status: 200,
       headers: {
         "Content-Type": "text/calendar; charset=utf-8",
-        "Content-Disposition": 'attachment; filename="n3q-events.ics"',
-        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Cache-Control": "public, max-age=3600",
       },
     });
   } catch (error) {


### PR DESCRIPTION
Improves ICS calendar spec compliance by adding a proper VTIMEZONE block for Europe/Copenhagen with correct CET/CEST DST transition rules. Adds CRLF line endings as required by RFC 5545. Includes REFRESH-INTERVAL and X-PUBLISHED-TTL headers for 1-hour refresh, with matching Cache-Control. Removes Content-Disposition to support inline calendar subscription.