### PR TITLE
Calendar email ingest and event modal interactions

### DIFF
--- a/apps/web/src/app/api/calendar/ingest/route.ts
+++ b/apps/web/src/app/api/calendar/ingest/route.ts
@@ -1,0 +1,232 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServiceClient } from "@/lib/supabase/service-client";
+
+interface PostmarkAttachment {
+  Name: string;
+  Content: string; // base64
+  ContentType: string;
+  ContentLength: number;
+}
+
+interface PostmarkInboundPayload {
+  From: string;
+  FromFull: { Email: string; Name: string };
+  To: string;
+  Subject: string;
+  TextBody: string;
+  HtmlBody: string;
+  Attachments: PostmarkAttachment[];
+}
+
+interface ParsedEvent {
+  uid: string | null;
+  summary: string | null;
+  description: string | null;
+  location: string | null;
+  dtstart: string | null;
+  dtend: string | null;
+}
+
+function parseICS(icsContent: string): ParsedEvent {
+  const lines: string[] = [];
+
+  // Unfold continuation lines (lines starting with space/tab are continuations)
+  for (const rawLine of icsContent.split(/\r?\n/)) {
+    if (rawLine.startsWith(" ") || rawLine.startsWith("\t")) {
+      if (lines.length > 0) {
+        lines[lines.length - 1] += rawLine.slice(1);
+      }
+    } else {
+      lines.push(rawLine);
+    }
+  }
+
+  let inEvent = false;
+  const event: ParsedEvent = {
+    uid: null,
+    summary: null,
+    description: null,
+    location: null,
+    dtstart: null,
+    dtend: null,
+  };
+
+  for (const line of lines) {
+    if (line === "BEGIN:VEVENT") {
+      inEvent = true;
+      continue;
+    }
+    if (line === "END:VEVENT") break;
+    if (!inEvent) continue;
+
+    // Parse property:value, handling parameters like DTSTART;TZID=...:value
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+
+    const propWithParams = line.slice(0, colonIdx);
+    const value = line.slice(colonIdx + 1);
+    const prop = propWithParams.split(";")[0].toUpperCase();
+
+    switch (prop) {
+      case "UID":
+        event.uid = value;
+        break;
+      case "SUMMARY":
+        event.summary = unescapeICS(value);
+        break;
+      case "DESCRIPTION":
+        event.description = unescapeICS(value);
+        break;
+      case "LOCATION":
+        event.location = unescapeICS(value);
+        break;
+      case "DTSTART":
+        event.dtstart = value;
+        break;
+      case "DTEND":
+        event.dtend = value;
+        break;
+    }
+  }
+
+  return event;
+}
+
+function unescapeICS(text: string): string {
+  return text
+    .replace(/\\n/gi, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}
+
+// Parse iCal datetime (20260407T143000 or 20260407) into date and time parts
+function parseICalDateTime(dt: string): { date: string; time: string | null } {
+  // Remove trailing Z for UTC
+  const clean = dt.replace(/Z$/, "");
+
+  if (clean.includes("T")) {
+    const [datePart, timePart] = clean.split("T");
+    const date = `${datePart.slice(0, 4)}-${datePart.slice(4, 6)}-${datePart.slice(6, 8)}`;
+    const time = `${timePart.slice(0, 2)}:${timePart.slice(2, 4)}:${timePart.slice(4, 6) || "00"}`;
+    return { date, time };
+  }
+
+  // Date only (all-day event)
+  const date = `${clean.slice(0, 4)}-${clean.slice(4, 6)}-${clean.slice(6, 8)}`;
+  return { date, time: null };
+}
+
+export async function POST(request: NextRequest) {
+  const client = createSupabaseServiceClient();
+  if (!client) {
+    return NextResponse.json({ error: "Service unavailable" }, { status: 500 });
+  }
+
+  let payload: PostmarkInboundPayload;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  // Find a .ics attachment (prefer text/calendar, fall back to .ics by name)
+  const icsAttachment = payload.Attachments?.find(
+    (a) =>
+      a.ContentType?.startsWith("text/calendar") ||
+      a.ContentType === "application/ics" ||
+      a.Name?.endsWith(".ics")
+  );
+
+  if (!icsAttachment || !icsAttachment.Content) {
+    console.log("Calendar ingest: no .ics attachment found, keys:",
+      JSON.stringify(payload.Attachments?.map(a => ({ Name: a.Name, ContentType: a.ContentType, hasContent: !!a.Content }))));
+    return NextResponse.json({ error: "No calendar attachment" }, { status: 400 });
+  }
+
+  // Decode base64 .ics content
+  const icsContent = Buffer.from(icsAttachment.Content, "base64").toString("utf-8");
+  const parsed = parseICS(icsContent);
+
+  if (!parsed.summary || !parsed.dtstart) {
+    console.log("Calendar ingest: could not parse event from .ics");
+    return NextResponse.json({ error: "Could not parse event" }, { status: 400 });
+  }
+
+  // Try to match sender to a member profile
+  const senderEmail = payload.FromFull?.Email?.toLowerCase();
+  let creatorId: string | null = null;
+
+  if (senderEmail) {
+    const { data: profile } = await client
+      .from("profiles")
+      .select("id")
+      .ilike("email", senderEmail)
+      .maybeSingle();
+
+    creatorId = profile?.id ?? null;
+  }
+
+  // If sender isn't a member, use the first available profile as fallback
+  if (!creatorId) {
+    const { data: fallback } = await client
+      .from("profiles")
+      .select("id")
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    creatorId = fallback?.id ?? null;
+  }
+
+  if (!creatorId) {
+    console.log("Calendar ingest: no profiles exist, cannot create event");
+    return NextResponse.json(
+      { error: "No profiles available" },
+      { status: 500 }
+    );
+  }
+
+  // Parse date/time
+  const start = parseICalDateTime(parsed.dtstart);
+  const end = parsed.dtend ? parseICalDateTime(parsed.dtend) : null;
+
+  // Check for duplicate by ical_uid
+  if (parsed.uid) {
+    const { data: existing } = await client
+      .from("events")
+      .select("id")
+      .eq("ical_uid", parsed.uid)
+      .maybeSingle();
+
+    if (existing) {
+      console.log(`Calendar ingest: duplicate event ${parsed.uid}, skipping`);
+      return NextResponse.json({ status: "duplicate", eventId: existing.id });
+    }
+  }
+
+  // Insert the event
+  const { data: event, error } = await client
+    .from("events")
+    .insert({
+      creator_id: creatorId,
+      title: parsed.summary,
+      description: parsed.description,
+      location: parsed.location,
+      event_date: start.date,
+      event_time: start.time,
+      event_end_time: end?.time ?? null,
+      is_public: false,
+      ical_uid: parsed.uid,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error("Calendar ingest: insert error", error);
+    return NextResponse.json({ error: "Failed to create event" }, { status: 500 });
+  }
+
+  console.log(`Calendar ingest: created event ${event.id} from ${senderEmail}`);
+  return NextResponse.json({ status: "created", eventId: event.id });
+}

--- a/apps/web/src/app/dashboard/events/components/create-event-modal.tsx
+++ b/apps/web/src/app/dashboard/events/components/create-event-modal.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Globe, Lock, X } from "lucide-react";
+import { useAuth } from "@/lib/auth/context";
+import { createEvent } from "@/lib/supabase/events";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+interface CreateEventModalProps {
+  initialDate: string | null;
+  onClose: () => void;
+  onCreated: (eventId: string) => void;
+}
+
+export function CreateEventModal({
+  initialDate,
+  onClose,
+  onCreated,
+}: CreateEventModalProps) {
+  const { userId: address } = useAuth();
+  const [title, setTitle] = useState("");
+  const [eventDate, setEventDate] = useState(initialDate || "");
+  const [eventTime, setEventTime] = useState("");
+  const [eventEndTime, setEventEndTime] = useState("");
+  const [description, setDescription] = useState("");
+  const [location, setLocation] = useState("");
+  const [isAllDay, setIsAllDay] = useState(false);
+  const [isPublic, setIsPublic] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!initialDate) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!address) return;
+    if (!title.trim() || !eventDate) return;
+
+    setIsSubmitting(true);
+    try {
+      const event = await createEvent(
+        address,
+        title.trim(),
+        eventDate,
+        description.trim() || null,
+        location.trim() || null,
+        isAllDay ? null : eventTime || null,
+        isPublic,
+        isAllDay ? null : eventEndTime || null
+      );
+
+      if (event) {
+        onCreated(event.id);
+      }
+    } catch (error) {
+      console.error("Error creating event:", error);
+      alert(error instanceof Error ? error.message : "Failed to create event");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-background/80 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <Card className="relative z-10 w-full max-w-lg mx-4 rounded-none shadow-lg max-h-[85vh] overflow-y-auto">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+          <CardTitle className="text-base font-semibold">New Event</CardTitle>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            className="h-8 w-8"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+              <label htmlFor="modal-title" className="text-sm font-medium">
+                What&apos;s happening? <span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="modal-title"
+                placeholder="Dinner, workshop, meetup..."
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="rounded-none"
+                maxLength={200}
+                autoFocus
+              />
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <label htmlFor="modal-date" className="text-sm font-medium">
+                  Date <span className="text-red-500">*</span>
+                </label>
+                <Input
+                  id="modal-date"
+                  type="date"
+                  value={eventDate}
+                  onChange={(e) => setEventDate(e.target.value)}
+                  className="rounded-none"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <label htmlFor="modal-time" className="text-sm font-medium">
+                    Time
+                  </label>
+                  <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={isAllDay}
+                      onChange={(e) => setIsAllDay(e.target.checked)}
+                      className="rounded"
+                    />
+                    All day
+                  </label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="modal-time"
+                    type="time"
+                    value={eventTime}
+                    onChange={(e) => setEventTime(e.target.value)}
+                    disabled={isAllDay}
+                    className="rounded-none"
+                  />
+                  <span className="text-xs text-muted-foreground shrink-0">to</span>
+                  <Input
+                    type="time"
+                    value={eventEndTime}
+                    onChange={(e) => setEventEndTime(e.target.value)}
+                    disabled={isAllDay}
+                    className="rounded-none"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <label htmlFor="modal-location" className="text-sm font-medium">
+                Location
+              </label>
+              <Input
+                id="modal-location"
+                placeholder="Address, venue, or video call link"
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                className="rounded-none"
+                maxLength={500}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label htmlFor="modal-description" className="text-sm font-medium">
+                Details
+              </label>
+              <Textarea
+                id="modal-description"
+                placeholder="Extra context, agenda, what to bring... (optional)"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                className="resize-none rounded-none"
+                maxLength={2000}
+              />
+            </div>
+
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setIsPublic(false)}
+                className={`flex-1 p-3 border text-left transition-colors ${
+                  !isPublic
+                    ? "border-amber-500 bg-amber-500/10"
+                    : "border-border hover:border-muted-foreground"
+                }`}
+              >
+                <div className="flex items-center gap-1.5">
+                  <Lock className="h-3.5 w-3.5" />
+                  <span className="font-medium text-xs">Members Only</span>
+                </div>
+              </button>
+              <button
+                type="button"
+                onClick={() => setIsPublic(true)}
+                className={`flex-1 p-3 border text-left transition-colors ${
+                  isPublic
+                    ? "border-amber-500 bg-amber-500/10"
+                    : "border-border hover:border-muted-foreground"
+                }`}
+              >
+                <div className="flex items-center gap-1.5">
+                  <Globe className="h-3.5 w-3.5" />
+                  <span className="font-medium text-xs">Public</span>
+                </div>
+              </button>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-1">
+              <Button type="button" variant="outline" size="sm" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={isSubmitting || !title.trim() || !eventDate}>
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                    Creating...
+                  </>
+                ) : (
+                  "Create Event"
+                )}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/events/components/event-detail-modal.tsx
+++ b/apps/web/src/app/dashboard/events/components/event-detail-modal.tsx
@@ -1,0 +1,494 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Calendar,
+  Clock,
+  MapPin,
+  Users,
+  Trash2,
+  Loader2,
+  UserPlus,
+  UserMinus,
+  Download,
+  ExternalLink,
+  X,
+} from "lucide-react";
+import { useAuth } from "@/lib/auth/context";
+import {
+  fetchEvent,
+  rsvpEvent,
+  cancelRsvp,
+  deleteEvent,
+} from "@/lib/supabase/events";
+import type { Event } from "@/lib/supabase/types";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { formatDistanceToNow } from "@/lib/utils";
+
+interface EventDetailModalProps {
+  eventId: string | null;
+  onClose: () => void;
+  onDeleted?: () => void;
+}
+
+function formatEventDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  return date.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function formatEventTime(timeStr: string | null): string | null {
+  if (!timeStr) return null;
+  const [hours, minutes] = timeStr.split(":");
+  const hour = parseInt(hours, 10);
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const hour12 = hour % 12 || 12;
+  return `${hour12}:${minutes} ${ampm}`;
+}
+
+function isEventPast(dateStr: string): boolean {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const eventDate = new Date(dateStr + "T00:00:00");
+  return eventDate < today;
+}
+
+function renderMarkdown(text: string): string {
+  return text
+    .replace(
+      /^### (.*$)/gm,
+      '<h3 class="text-base font-semibold mt-4 mb-2">$1</h3>'
+    )
+    .replace(
+      /^## (.*$)/gm,
+      '<h2 class="text-lg font-semibold mt-4 mb-2">$1</h2>'
+    )
+    .replace(
+      /^# (.*$)/gm,
+      '<h1 class="text-xl font-semibold mt-4 mb-2">$1</h1>'
+    )
+    .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.*?)\*/g, "<em>$1</em>")
+    .replace(
+      /\[([^\]]+)\]\(([^)]+)\)/g,
+      '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-amber-500 hover:underline">$1</a>'
+    )
+    .replace(
+      /`([^`]+)`/g,
+      '<code class="bg-muted px-1.5 py-0.5 text-sm font-mono">$1</code>'
+    )
+    .replace(/\n/g, "<br />");
+}
+
+const EVENT_TIMEZONE = "Europe/Copenhagen";
+
+function formatICSTime(timeStr: string): string {
+  const parts = timeStr.split(":");
+  return `${parts[0]}${parts[1]}${parts[2] ? parts[2] : "00"}`;
+}
+
+function generateSingleEventICS(event: Event): string {
+  const now = new Date();
+  const timestamp = now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
+  const uid = `${event.id}@n3q.events`;
+  const created = new Date(event.created_at)
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}/, "");
+
+  let dateProps: string;
+
+  if (event.event_time) {
+    const dateFormatted = event.event_date.replace(/-/g, "");
+    const dtstart = `${dateFormatted}T${formatICSTime(event.event_time)}`;
+
+    let dtend: string;
+    if (event.event_end_time) {
+      dtend = `${dateFormatted}T${formatICSTime(event.event_end_time)}`;
+    } else {
+      const timeParts = event.event_time.split(":");
+      const endHour = String(Math.min(parseInt(timeParts[0], 10) + 2, 23)).padStart(2, "0");
+      dtend = `${dateFormatted}T${endHour}${timeParts[1]}00`;
+    }
+    dateProps = `DTSTART;TZID=${EVENT_TIMEZONE}:${dtstart}\nDTEND;TZID=${EVENT_TIMEZONE}:${dtend}`;
+  } else {
+    const dtstart = event.event_date.replace(/-/g, "");
+    const nextDay = new Date(event.event_date + "T12:00:00");
+    nextDay.setDate(nextDay.getDate() + 1);
+    const dtend = nextDay.toISOString().split("T")[0].replace(/-/g, "");
+    dateProps = `DTSTART;VALUE=DATE:${dtstart}\nDTEND;VALUE=DATE:${dtend}`;
+  }
+
+  const escapeText = (text: string | null): string => {
+    if (!text) return "";
+    return text
+      .replace(/\\/g, "\\\\")
+      .replace(/;/g, "\\;")
+      .replace(/,/g, "\\,")
+      .replace(/\n/g, "\\n");
+  };
+
+  let ics = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//N3Q//Events//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VEVENT
+UID:${uid}
+DTSTAMP:${timestamp}
+CREATED:${created}
+${dateProps}
+SUMMARY:${escapeText(event.title)}`;
+
+  if (event.description) {
+    ics += `\nDESCRIPTION:${escapeText(event.description)}`;
+  }
+  if (event.location) {
+    ics += `\nLOCATION:${escapeText(event.location)}`;
+  }
+
+  ics += `\nEND:VEVENT\nEND:VCALENDAR`;
+  return ics;
+}
+
+export function EventDetailModal({ eventId, onClose, onDeleted }: EventDetailModalProps) {
+  const { userId: address } = useAuth();
+  const [event, setEvent] = useState<Event | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  useEffect(() => {
+    if (!eventId || !address) return;
+
+    setIsLoading(true);
+    setShowDeleteConfirm(false);
+    fetchEvent(eventId, address).then((data) => {
+      setEvent(data);
+      setIsLoading(false);
+    });
+  }, [eventId, address]);
+
+  if (!eventId) return null;
+
+  const isCreator =
+    address && event?.creator_id.toLowerCase() === address.toLowerCase();
+  const hasRsvp = event?.user_has_rsvp;
+  const isPast = event ? isEventPast(event.event_date) : false;
+
+  const handleRsvp = async () => {
+    if (!address || !event) return;
+    setActionLoading("rsvp");
+    try {
+      await rsvpEvent(event.id, address);
+      const updated = await fetchEvent(event.id, address);
+      setEvent(updated);
+    } catch (error) {
+      console.error("Error RSVPing:", error);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleCancelRsvp = async () => {
+    if (!address || !event) return;
+    setActionLoading("cancel");
+    try {
+      await cancelRsvp(event.id, address);
+      const updated = await fetchEvent(event.id, address);
+      setEvent(updated);
+    } catch (error) {
+      console.error("Error canceling RSVP:", error);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!address || !event) return;
+    setActionLoading("delete");
+    try {
+      await deleteEvent(event.id, address);
+      onDeleted?.();
+      onClose();
+    } catch (error) {
+      console.error("Error deleting event:", error);
+      setActionLoading(null);
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  const handleDownloadICS = () => {
+    if (!event) return;
+    const icsContent = generateSingleEventICS(event);
+    const blob = new Blob([icsContent], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${event.title.replace(/[^a-z0-9]/gi, "-").toLowerCase()}.ics`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const formattedDate = event ? formatEventDate(event.event_date) : "";
+  const formattedTime = event ? formatEventTime(event.event_time) : null;
+  const isLocationUrl = event?.location?.startsWith("http");
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-background/80 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <Card className="relative z-10 w-full max-w-lg mx-4 rounded-none shadow-lg max-h-[85vh] overflow-y-auto">
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-3">
+          <div className="flex-1 min-w-0 pr-4">
+            {isLoading ? (
+              <div className="h-6 w-48 bg-muted animate-pulse" />
+            ) : event ? (
+              <div className="flex items-start gap-2">
+                <CardTitle className="text-base font-semibold leading-tight">
+                  {event.title}
+                </CardTitle>
+                {isPast && (
+                  <Badge variant="secondary" className="shrink-0 text-[10px]">
+                    Past
+                  </Badge>
+                )}
+              </div>
+            ) : (
+              <CardTitle className="text-base">Event not found</CardTitle>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            className="h-8 w-8 shrink-0"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </CardHeader>
+
+        {isLoading ? (
+          <CardContent className="flex items-center justify-center py-12">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </CardContent>
+        ) : event ? (
+          <CardContent className="space-y-4">
+            {/* Date/time/location */}
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1.5">
+                <Calendar className="h-3.5 w-3.5" />
+                {formattedDate}
+              </span>
+              {formattedTime ? (
+                <span className="flex items-center gap-1.5">
+                  <Clock className="h-3.5 w-3.5" />
+                  {formattedTime}
+                  {event.event_end_time &&
+                    ` - ${formatEventTime(event.event_end_time)}`}
+                </span>
+              ) : (
+                <Badge variant="outline" className="text-xs w-fit">
+                  All day
+                </Badge>
+              )}
+              {event.location && (
+                <div className="flex items-center gap-1.5">
+                  <MapPin className="h-3.5 w-3.5 shrink-0" />
+                  {isLocationUrl ? (
+                    <a
+                      href={event.location}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-amber-500 hover:underline flex items-center gap-1"
+                    >
+                      {event.location}
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  ) : (
+                    <span>{event.location}</span>
+                  )}
+                </div>
+              )}
+              <span className="flex items-center gap-1.5">
+                <Users className="h-3.5 w-3.5" />
+                {event.rsvp_count || 0} attending
+              </span>
+            </div>
+
+            {/* Description */}
+            {event.description && (
+              <div className="border-t border-border pt-3">
+                <div
+                  className="prose prose-sm dark:prose-invert max-w-none text-sm"
+                  dangerouslySetInnerHTML={{
+                    __html: renderMarkdown(event.description),
+                  }}
+                />
+              </div>
+            )}
+
+            {/* Attendees */}
+            {event.rsvps && event.rsvps.length > 0 && (
+              <div className="border-t border-border pt-3 space-y-2">
+                <p className="text-xs font-medium text-muted-foreground">
+                  Attending ({event.rsvps.length})
+                </p>
+                <div className="space-y-2">
+                  {event.rsvps.slice(0, 5).map((rsvp) => {
+                    const displayName =
+                      rsvp.user?.display_name ||
+                      `${rsvp.user_id.slice(0, 6)}...${rsvp.user_id.slice(-4)}`;
+                    const initials = rsvp.user?.display_name
+                      ? rsvp.user.display_name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")
+                          .toUpperCase()
+                          .slice(0, 2)
+                      : rsvp.user_id.slice(2, 4).toUpperCase();
+
+                    return (
+                      <div key={rsvp.id} className="flex items-center gap-2">
+                        <Avatar className="h-6 w-6">
+                          <AvatarImage
+                            src={rsvp.user?.avatar_url || undefined}
+                            alt={displayName}
+                          />
+                          <AvatarFallback className="text-[8px]">
+                            {initials}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className={`text-xs ${!rsvp.user?.display_name ? "font-mono" : ""}`}>
+                          {displayName}
+                        </span>
+                      </div>
+                    );
+                  })}
+                  {event.rsvps.length > 5 && (
+                    <p className="text-xs text-muted-foreground">
+                      +{event.rsvps.length - 5} more
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="border-t border-border pt-3 flex flex-wrap items-center gap-2">
+              {!isPast && !hasRsvp && (
+                <Button
+                  onClick={handleRsvp}
+                  disabled={actionLoading === "rsvp"}
+                  size="sm"
+                  className="gap-1.5"
+                >
+                  {actionLoading === "rsvp" ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <UserPlus className="h-3.5 w-3.5" />
+                  )}
+                  I&apos;m Going
+                </Button>
+              )}
+
+              {!isPast && hasRsvp && (
+                <Button
+                  onClick={handleCancelRsvp}
+                  disabled={actionLoading === "cancel"}
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                >
+                  {actionLoading === "cancel" ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <UserMinus className="h-3.5 w-3.5" />
+                  )}
+                  Cancel RSVP
+                </Button>
+              )}
+
+              <Button
+                onClick={handleDownloadICS}
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+              >
+                <Download className="h-3.5 w-3.5" />
+                Add to Calendar
+              </Button>
+
+              {isCreator && (
+                <>
+                  {!showDeleteConfirm ? (
+                    <Button
+                      onClick={() => setShowDeleteConfirm(true)}
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5 text-red-500 hover:text-red-500 hover:bg-red-500/10"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Delete
+                    </Button>
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-red-500">Sure?</span>
+                      <Button
+                        onClick={handleDelete}
+                        disabled={actionLoading === "delete"}
+                        variant="destructive"
+                        size="sm"
+                      >
+                        {actionLoading === "delete" ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          "Yes"
+                        )}
+                      </Button>
+                      <Button
+                        onClick={() => setShowDeleteConfirm(false)}
+                        variant="outline"
+                        size="sm"
+                      >
+                        No
+                      </Button>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+
+            {/* Meta */}
+            <p className="text-[11px] text-muted-foreground">
+              Created {formatDistanceToNow(new Date(event.created_at))}
+              {event.creator && (
+                <>
+                  {" "}by{" "}
+                  {event.creator.display_name ||
+                    `${event.creator_id.slice(0, 6)}...`}
+                </>
+              )}
+            </p>
+          </CardContent>
+        ) : (
+          <CardContent>
+            <p className="text-sm text-muted-foreground">Event not found.</p>
+          </CardContent>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/events/page.tsx
+++ b/apps/web/src/app/dashboard/events/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Plus, Calendar, ChevronLeft, ChevronRight, MapPin, Clock } from "lucide-react";
+import { Plus, Calendar, ChevronLeft, ChevronRight, MapPin, Clock, Mail } from "lucide-react";
 import { useAuth } from "@/lib/auth/context";
 import { fetchEvents } from "@/lib/supabase/events";
 import type { Event } from "@/lib/supabase/types";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { CalendarGuideModal } from "./components/calendar-guide-modal";
+import { EventDetailModal } from "./components/event-detail-modal";
+import { CreateEventModal } from "./components/create-event-modal";
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
@@ -67,6 +69,8 @@ export default function EventsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [showCalendarGuide, setShowCalendarGuide] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [modalEventId, setModalEventId] = useState<string | null>(null);
+  const [createDate, setCreateDate] = useState<string | null>(null);
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -78,22 +82,21 @@ export default function EventsPage() {
       ? `${window.location.origin}/api/calendar`
       : "";
 
-  useEffect(() => {
+  const loadEvents = useCallback(async () => {
     if (!address) return;
-
-    const load = async () => {
-      setIsLoading(true);
-      const [upcoming, past] = await Promise.all([
-        fetchEvents(address, "upcoming"),
-        fetchEvents(address, "past"),
-      ]);
-      setAllEvents(upcoming);
-      setPastEvents(past);
-      setIsLoading(false);
-    };
-
-    load();
+    setIsLoading(true);
+    const [upcoming, past] = await Promise.all([
+      fetchEvents(address, "upcoming"),
+      fetchEvents(address, "past"),
+    ]);
+    setAllEvents(upcoming);
+    setPastEvents(past);
+    setIsLoading(false);
   }, [address]);
+
+  useEffect(() => {
+    loadEvents();
+  }, [loadEvents]);
 
   const eventsByDate = useMemo(() => {
     const map: Record<string, Event[]> = {};
@@ -157,6 +160,19 @@ export default function EventsPage() {
       })
     : "Upcoming";
 
+  const handleDayDoubleClick = (date: Date) => {
+    setCreateDate(dateKey(date));
+  };
+
+  const handleEventCreated = () => {
+    setCreateDate(null);
+    loadEvents();
+  };
+
+  const handleEventDeleted = () => {
+    loadEvents();
+  };
+
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
       <div className="flex items-start justify-between gap-4">
@@ -178,6 +194,15 @@ export default function EventsPage() {
             </Button>
           </Link>
         </div>
+      </div>
+
+      {/* Email invite hint */}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/50 border border-border px-3 py-2">
+        <Mail className="h-3.5 w-3.5 shrink-0" />
+        <span>
+          Invite <code className="bg-muted px-1 py-0.5 font-mono text-[11px]">events@n3q.house</code> to
+          any calendar event to automatically add it here.
+        </span>
       </div>
 
       {isLoading ? (
@@ -233,6 +258,7 @@ export default function EventsPage() {
                     key={i}
                     type="button"
                     onClick={() => setSelectedDate(date)}
+                    onDoubleClick={() => handleDayDoubleClick(date)}
                     className={`relative min-h-[72px] border-b border-r border-border p-1.5 text-left transition-colors ${
                       !inMonth ? "bg-muted/20 text-muted-foreground/40" : ""
                     } ${isSelected ? "bg-accent" : "hover:bg-muted/40"} ${
@@ -253,7 +279,11 @@ export default function EventsPage() {
                         {dayEvents.slice(0, 2).map((ev) => (
                           <div
                             key={ev.id}
-                            className="truncate rounded-sm bg-amber-500/15 px-1 py-0.5 text-[10px] leading-tight text-amber-600 dark:text-amber-400"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setModalEventId(ev.id);
+                            }}
+                            className="truncate rounded-sm bg-amber-500/15 px-1 py-0.5 text-[10px] leading-tight text-amber-600 dark:text-amber-400 hover:bg-amber-500/25 cursor-pointer"
                           >
                             {ev.title}
                           </div>
@@ -291,22 +321,24 @@ export default function EventsPage() {
                   {selectedDate ? "No events this day" : "No upcoming events"}
                 </p>
                 {selectedDate && (
-                  <Link
-                    href={`/dashboard/events/create`}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-2"
+                    onClick={() => handleDayDoubleClick(selectedDate)}
                   >
-                    <Button variant="outline" size="sm" className="gap-2">
-                      <Plus className="h-3 w-3" />
-                      Create one
-                    </Button>
-                  </Link>
+                    <Plus className="h-3 w-3" />
+                    Create one
+                  </Button>
                 )}
               </div>
             ) : (
               sidebarEvents.map((event) => (
-                <Link
+                <button
                   key={event.id}
-                  href={`/dashboard/events/${event.id}`}
-                  className="block border border-border p-3 hover:border-foreground/20 transition-colors space-y-2"
+                  type="button"
+                  onClick={() => setModalEventId(event.id)}
+                  className="block w-full border border-border p-3 hover:border-foreground/20 transition-colors space-y-2 text-left"
                 >
                   <div className="text-sm font-medium leading-tight">
                     {event.title}
@@ -358,7 +390,7 @@ export default function EventsPage() {
                       </span>
                     </div>
                   )}
-                </Link>
+                </button>
               ))
             )}
           </div>
@@ -369,6 +401,18 @@ export default function EventsPage() {
         isOpen={showCalendarGuide}
         onClose={() => setShowCalendarGuide(false)}
         calendarUrl={calendarUrl}
+      />
+
+      <EventDetailModal
+        eventId={modalEventId}
+        onClose={() => setModalEventId(null)}
+        onDeleted={handleEventDeleted}
+      />
+
+      <CreateEventModal
+        initialDate={createDate}
+        onClose={() => setCreateDate(null)}
+        onCreated={handleEventCreated}
       />
     </div>
   );

--- a/apps/web/supabase/migrations/add_ical_uid.sql
+++ b/apps/web/supabase/migrations/add_ical_uid.sql
@@ -1,0 +1,2 @@
+-- Add ical_uid column for deduplicating events created via calendar invite ingestion
+alter table public.events add column if not exists ical_uid text unique;

--- a/apps/web/supabase/schema.sql
+++ b/apps/web/supabase/schema.sql
@@ -356,6 +356,7 @@ create table if not exists public.events (
   event_date date not null,
   event_time time,
   is_public boolean not null default false,
+  ical_uid text unique,
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary

- **Calendar email ingest**: New Postmark webhook at `/api/calendar/ingest` receives emails sent to `events@n3q.house`, parses `.ics` attachments, and auto-creates events in Supabase. Supports deduplication via `ical_uid` column.
- **Event modals**: Clicking an event in the calendar or sidebar now opens a detail modal instead of navigating to a new page. Double-clicking a calendar day opens a create event modal with that date pre-filled.
- **Email invite hint**: Banner on the events page telling users they can invite `events@n3q.house` to any calendar event.

## Changes

- [x] `apps/web`
- [ ] `apps/mobile`
- [ ] `packages/shared`

## Test plan

- Deploy to Vercel, run `add_ical_uid` migration on Supabase
- Send a calendar invite to `events@n3q.house` and verify it appears in the events list
- Click an event in the calendar grid — should open detail modal
- Double-click a day — should open create event modal with date pre-filled
- Retry the test webhook in Postmark Activity tab to verify end-to-end flow

## Screenshots

<!-- UI changes are modal overlays on existing events page -->