### PR TITLE
Fix reanimated worklets, pin React 19.1.0, and polish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      expo:
-        patterns:
-          - "expo*"
-          - "@expo/*"
-          - "react-native*"
-        update-types:
-          - "minor"
-          - "patch"
       supabase:
         patterns:
           - "@supabase/*"
@@ -24,10 +16,17 @@ updates:
         update-types: ["version-update:semver-major"]
       # React must match react-native-renderer version exactly.
       # RN 0.81.5 ships renderer@19.1.0 — bumping react breaks the mobile app.
-      # Remove this ignore when upgrading to RN 0.82+
+      # Remove these ignores when upgrading Expo SDK.
       - dependency-name: "react"
       - dependency-name: "react-dom"
       - dependency-name: "@types/react"
+      # Expo/RN packages are tightly coupled to the Expo SDK version.
+      # They must be upgraded together via `expo install --fix`, not individually.
+      # Remove these ignores when upgrading to the next Expo SDK.
+      - dependency-name: "expo*"
+      - dependency-name: "@expo/*"
+      - dependency-name: "react-native"
+      - dependency-name: "react-native-*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -33,8 +33,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/mobile-update.yml
+++ b/.github/workflows/mobile-update.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -50,7 +50,8 @@
         {
           "calendarPermission": "Allow N3Q to add events to your calendar."
         }
-      ]
+      ],
+      "./plugins/withWidget"
     ],
     "updates": {
       "url": "https://u.expo.dev/cdb8a70f-0945-45dc-89d1-f358e5a80009"


### PR DESCRIPTION
## Summary

- Fix reanimated Worklets crash (missing babel.config.js)
- Pin React 19.1.0 for RN 0.81.5 renderer compatibility
- Fix calendar timezone parsing and error handling
- Update widget deep links to match Expo Router paths
- Widget data updates after RSVP
- Fix pnpm version conflict in GitHub Actions
- Ignore Expo/RN packages in dependabot (must upgrade with SDK)
- Full-screen splash screen PNG

## Changes

- [x] `apps/mobile`
- [x] `.github/workflows`

## Test plan

- Dev build tested on iOS simulator
- TypeScript passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)