### PR TITLE
Add Android widgets

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -51,7 +51,65 @@
           "calendarPermission": "Allow N3Q to add events to your calendar."
         }
       ],
-      "./plugins/withWidget"
+      "./plugins/withWidget",
+      [
+        "react-native-android-widget",
+        {
+          "fonts": ["./assets/fonts/DepartureMono-Regular.otf"],
+          "widgets": [
+            {
+              "name": "EventsWidget",
+              "label": "N3Q Events",
+              "description": "Upcoming events from the community.",
+              "minWidth": "256dp",
+              "minHeight": "120dp",
+              "targetCellWidth": 4,
+              "targetCellHeight": 2,
+              "resizeMode": "vertical",
+              "updatePeriodMillis": 1800000
+            },
+            {
+              "name": "ProjectsWidget",
+              "label": "N3Q Projects",
+              "description": "Active projects and their status.",
+              "minWidth": "256dp",
+              "minHeight": "120dp",
+              "targetCellWidth": 4,
+              "targetCellHeight": 2,
+              "resizeMode": "vertical",
+              "updatePeriodMillis": 3600000
+            },
+            {
+              "name": "QuickActionsWidget",
+              "label": "N3Q Quick Actions",
+              "description": "Post, create an event, or start a project.",
+              "minWidth": "110dp",
+              "minHeight": "110dp",
+              "targetCellWidth": 2,
+              "targetCellHeight": 2
+            },
+            {
+              "name": "MemberCardWidget",
+              "label": "Member Card",
+              "description": "Your N3Q trading card on your home screen.",
+              "minWidth": "110dp",
+              "minHeight": "110dp",
+              "targetCellWidth": 2,
+              "targetCellHeight": 2,
+              "updatePeriodMillis": 86400000
+            },
+            {
+              "name": "BrandWidget",
+              "label": "N3Q",
+              "description": "A lab for builders, backed by unicorn founders.",
+              "minWidth": "110dp",
+              "minHeight": "110dp",
+              "targetCellWidth": 2,
+              "targetCellHeight": 2
+            }
+          ]
+        }
+      ]
     ],
     "updates": {
       "url": "https://u.expo.dev/cdb8a70f-0945-45dc-89d1-f358e5a80009"

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -1,0 +1,7 @@
+import { registerWidgetTaskHandler } from "react-native-android-widget";
+import { widgetTaskHandler } from "./src/widgets/handler";
+
+registerWidgetTaskHandler(widgetTaskHandler);
+
+// Re-export expo-router entry
+import "expo-router/entry";

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n3q/mobile",
-  "main": "expo-router/entry",
+  "main": "./index.ts",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -43,6 +43,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-android-widget": "^0.20.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/apps/mobile/src/lib/auth/context.tsx
+++ b/apps/mobile/src/lib/auth/context.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useCallback, useContext, useEffect, useRef, useSt
 import * as SecureStore from "expo-secure-store";
 import type { Profile } from "@n3q/shared";
 import { supabase } from "../supabase/client";
+import { updateWidgetProfile, clearWidgetProfile } from "../widget-data";
+import { daysSince } from "../days";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL;
 
@@ -89,6 +91,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     if (data) {
       setProfile(data);
+      // Push profile to widget (iOS + Android)
+      const name = data.display_name || "Member";
+      const initials = name.split(" ").map((w: string) => w[0]).join("").toUpperCase().slice(0, 2);
+      updateWidgetProfile({
+        displayName: name,
+        initials,
+        avatarUrl: data.avatar_url || null,
+        dayCount: data.created_at ? daysSince(data.created_at) : 1,
+      });
     }
   }
 
@@ -166,6 +177,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setIsAuthenticated(false);
     setUserId(null);
     setProfile(null);
+    clearWidgetProfile();
   }
 
   return (

--- a/apps/mobile/src/lib/widget-data.ts
+++ b/apps/mobile/src/lib/widget-data.ts
@@ -1,4 +1,5 @@
-import { setItem, reloadAllTimelines } from "react-native-widgetkit";
+import { Platform } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export interface WidgetEvent {
   id: string;
@@ -15,20 +16,87 @@ export interface WidgetProject {
   memberCount: number;
 }
 
-export async function updateWidgetEvents(events: WidgetEvent[]) {
+export interface WidgetProfile {
+  displayName: string;
+  initials: string;
+  avatarUrl: string | null;
+  dayCount: number;
+}
+
+// iOS: write to UserDefaults via react-native-widgetkit
+// Android: write to AsyncStorage + trigger widget update via react-native-android-widget
+
+async function writeToiOS(key: string, value: string) {
   try {
-    await setItem("widget_events", JSON.stringify(events.slice(0, 5)), "group.com.n3q.app");
+    const { setItem, reloadAllTimelines } = require("react-native-widgetkit");
+    await setItem(key, value, "group.com.n3q.app");
     reloadAllTimelines();
   } catch {
     // Widget data sharing not available (e.g., Expo Go)
   }
 }
 
-export async function updateWidgetProjects(projects: WidgetProject[]) {
+async function updateAndroidWidget(widgetName: string) {
   try {
-    await setItem("widget_projects", JSON.stringify(projects.slice(0, 5)), "group.com.n3q.app");
-    reloadAllTimelines();
+    const { requestWidgetUpdate } = require("react-native-android-widget");
+    const { widgetTaskHandler } = require("../widgets/handler");
+    // requestWidgetUpdate calls the task handler which reads from AsyncStorage
+    await requestWidgetUpdate({
+      widgetName,
+      renderWidget: async (info: any) => {
+        // The handler will read fresh data from AsyncStorage
+        return new Promise<any>((resolve) => {
+          widgetTaskHandler({
+            widgetInfo: info,
+            widgetAction: "WIDGET_UPDATE",
+            renderWidget: resolve,
+          });
+        });
+      },
+    });
   } catch {
-    // Widget data sharing not available
+    // Android widget not available
+  }
+}
+
+export async function updateWidgetEvents(events: WidgetEvent[]) {
+  const data = JSON.stringify(events.slice(0, 5));
+
+  if (Platform.OS === "ios") {
+    await writeToiOS("widget_events", data);
+  } else {
+    await AsyncStorage.setItem("widget_events_android", data);
+    await updateAndroidWidget("EventsWidget");
+  }
+}
+
+export async function updateWidgetProjects(projects: WidgetProject[]) {
+  const data = JSON.stringify(projects.slice(0, 5));
+
+  if (Platform.OS === "ios") {
+    await writeToiOS("widget_projects", data);
+  } else {
+    await AsyncStorage.setItem("widget_projects_android", data);
+    await updateAndroidWidget("ProjectsWidget");
+  }
+}
+
+export async function updateWidgetProfile(profile: WidgetProfile) {
+  const data = JSON.stringify(profile);
+
+  if (Platform.OS === "ios") {
+    await writeToiOS("widget_profile", data);
+  } else {
+    await AsyncStorage.setItem("widget_profile_android", data);
+    await updateAndroidWidget("MemberCardWidget");
+  }
+}
+
+export async function clearWidgetProfile() {
+  if (Platform.OS === "ios") {
+    await writeToiOS("widget_profile", "");
+  } else {
+    await AsyncStorage.removeItem("widget_profile_android");
+    await updateAndroidWidget("MemberCardWidget");
   }
 }

--- a/apps/mobile/src/widgets/BrandWidget.tsx
+++ b/apps/mobile/src/widgets/BrandWidget.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { FlexWidget, TextWidget } from "react-native-android-widget";
+import { w } from "./theme";
+
+interface Props {
+  width: number;
+}
+
+export function BrandWidget({ width }: Props) {
+  const isWide = width > 200;
+
+  return (
+    <FlexWidget
+      clickAction="OPEN_APP"
+      style={{
+        flexDirection: "column",
+        backgroundColor: w.cardBg,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: w.gold25,
+        height: "match_parent" as any,
+        width: "match_parent" as any,
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 14,
+      }}
+    >
+      {/* Logo */}
+      <TextWidget
+        text="N3Q"
+        style={{
+          fontSize: isWide ? 28 : 22,
+          fontFamily: "DepartureMono",
+          fontWeight: "bold",
+          color: w.amber,
+          letterSpacing: 4,
+        }}
+      />
+
+      <FlexWidget style={{ height: isWide ? 10 : 8 }} />
+
+      {/* Diamond divider */}
+      <FlexWidget
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          width: "match_parent" as any,
+          paddingHorizontal: isWide ? 40 : 16,
+          flexGap: 8,
+        }}
+      >
+        <FlexWidget
+          style={{
+            flex: 1,
+            height: 1,
+            backgroundColor: w.gold25,
+          }}
+        />
+        <FlexWidget
+          style={{
+            width: 4,
+            height: 4,
+            backgroundColor: w.gold60,
+            borderRadius: 1,
+          }}
+        />
+        <FlexWidget
+          style={{
+            flex: 1,
+            height: 1,
+            backgroundColor: w.gold25,
+          }}
+        />
+      </FlexWidget>
+
+      <FlexWidget style={{ height: isWide ? 10 : 8 }} />
+
+      {/* Tagline */}
+      <TextWidget
+        text="A lab for builders, backed"
+        style={{
+          fontSize: isWide ? 11 : 9,
+          fontFamily: "DepartureMono",
+          color: w.mutedAmber,
+          textAlign: "center",
+        }}
+      />
+      <TextWidget
+        text="by unicorn founders"
+        style={{
+          fontSize: isWide ? 11 : 9,
+          fontFamily: "DepartureMono",
+          color: w.mutedAmber,
+          textAlign: "center",
+        }}
+      />
+    </FlexWidget>
+  );
+}

--- a/apps/mobile/src/widgets/EventsWidget.tsx
+++ b/apps/mobile/src/widgets/EventsWidget.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { FlexWidget, TextWidget } from "react-native-android-widget";
+import { w } from "./theme";
+import type { WidgetEvent } from "../lib/widget-data";
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrow = new Date(today.getTime() + 86400000);
+
+  if (d.getTime() === today.getTime()) return "Today";
+  if (d.getTime() === tomorrow.getTime()) return "Tomorrow";
+
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatTime(time: string | null): string | null {
+  if (!time) return null;
+  const [h, m] = time.split(":");
+  const hour = parseInt(h, 10);
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const h12 = hour % 12 || 12;
+  return `${h12}:${m} ${ampm}`;
+}
+
+interface Props {
+  events: WidgetEvent[];
+  width: number;
+  height: number;
+}
+
+export function EventsWidget({ events, height }: Props) {
+  const maxItems = height > 200 ? 4 : 3;
+
+  return (
+    <FlexWidget
+      style={{
+        flexDirection: "column",
+        backgroundColor: w.pageBg,
+        borderRadius: 16,
+        padding: 14,
+        height: "match_parent" as any,
+        width: "match_parent" as any,
+      }}
+    >
+      {/* Header */}
+      <FlexWidget
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          width: "match_parent" as any,
+        }}
+      >
+        <TextWidget
+          text="N3Q EVENTS"
+          style={{
+            fontSize: 11,
+            fontFamily: "DepartureMono",
+            color: w.amber,
+          }}
+        />
+        <TextWidget
+          text="All ▸"
+          clickAction="OPEN_APP"
+          clickActionData={{ screen: "(tabs)/events" }}
+          style={{
+            fontSize: 10,
+            fontFamily: "DepartureMono",
+            color: w.gray,
+          }}
+        />
+      </FlexWidget>
+
+      {/* Spacer */}
+      <FlexWidget style={{ height: 8 }} />
+
+      {/* Event list */}
+      {events.length === 0 ? (
+        <FlexWidget
+          style={{
+            flex: 1,
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <TextWidget
+            text="No upcoming events"
+            style={{ fontSize: 12, fontFamily: "DepartureMono", color: w.gray }}
+          />
+        </FlexWidget>
+      ) : (
+        events.slice(0, maxItems).map((event) => (
+          <FlexWidget
+            key={event.id}
+            clickAction="OPEN_APP"
+            clickActionData={{ screen: `(tabs)/events/${event.id}` }}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              width: "match_parent" as any,
+              padding: 4,
+              flexGap: 8,
+            }}
+          >
+            {/* Dot */}
+            <FlexWidget
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: w.amberStatus,
+              }}
+            />
+            {/* Title */}
+            <FlexWidget style={{ flex: 1 }}>
+              <TextWidget
+                text={event.title}
+                maxLines={1}
+                style={{ fontSize: 13, color: w.white }}
+              />
+            </FlexWidget>
+            {/* Date/time */}
+            <FlexWidget style={{ flexDirection: "column", alignItems: "flex-end" }}>
+              <TextWidget
+                text={formatDate(event.date)}
+                style={{ fontSize: 11, fontFamily: "DepartureMono", color: w.gray }}
+              />
+              {event.time && (
+                <TextWidget
+                  text={formatTime(event.time) || ""}
+                  style={{ fontSize: 10, fontFamily: "DepartureMono", color: w.gray }}
+                />
+              )}
+            </FlexWidget>
+          </FlexWidget>
+        ))
+      )}
+    </FlexWidget>
+  );
+}

--- a/apps/mobile/src/widgets/MemberCardWidget.tsx
+++ b/apps/mobile/src/widgets/MemberCardWidget.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { FlexWidget, TextWidget } from "react-native-android-widget";
+import { w } from "./theme";
+import type { WidgetProfile } from "../lib/widget-data";
+
+interface Props {
+  profile: WidgetProfile | null;
+}
+
+export function MemberCardWidget({ profile }: Props) {
+  if (!profile) {
+    return (
+      <FlexWidget
+        clickAction="OPEN_APP"
+        style={{
+          flexDirection: "column",
+          backgroundColor: w.cardBg,
+          borderRadius: 16,
+          padding: 14,
+          height: "match_parent" as any,
+          width: "match_parent" as any,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <TextWidget
+          text="N3Q"
+          style={{
+            fontSize: 18,
+            fontFamily: "DepartureMono",
+            fontWeight: "bold",
+            color: w.amber,
+          }}
+        />
+        <FlexWidget style={{ height: 8 }} />
+        <TextWidget
+          text="Open app to"
+          style={{ fontSize: 11, fontFamily: "DepartureMono", color: w.gray, textAlign: "center" }}
+        />
+        <TextWidget
+          text="set up card"
+          style={{ fontSize: 11, fontFamily: "DepartureMono", color: w.gray, textAlign: "center" }}
+        />
+      </FlexWidget>
+    );
+  }
+
+  return (
+    <FlexWidget
+      clickAction="OPEN_APP"
+      clickActionData={{ screen: "profile" }}
+      style={{
+        flexDirection: "column",
+        backgroundColor: w.cardBg,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: w.gold25,
+        height: "match_parent" as any,
+        width: "match_parent" as any,
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 12,
+      }}
+    >
+      {/* Avatar / Initials */}
+      <FlexWidget
+        style={{
+          width: 52,
+          height: 52,
+          borderRadius: 2,
+          borderWidth: 1,
+          borderColor: w.gold50,
+          backgroundColor: w.cardBgDark,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <TextWidget
+          text={profile.initials}
+          style={{
+            fontSize: 22,
+            fontFamily: "DepartureMono",
+            fontWeight: "bold",
+            color: w.amber,
+          }}
+        />
+      </FlexWidget>
+
+      <FlexWidget style={{ height: 6 }} />
+
+      {/* Name */}
+      <TextWidget
+        text={profile.displayName.toUpperCase()}
+        maxLines={1}
+        style={{
+          fontSize: 11,
+          fontFamily: "DepartureMono",
+          fontWeight: "600",
+          color: w.amber,
+          letterSpacing: 1,
+        }}
+      />
+
+      <FlexWidget style={{ height: 4 }} />
+
+      {/* Builder divider */}
+      <FlexWidget
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          width: "match_parent" as any,
+          paddingHorizontal: 8,
+          flexGap: 6,
+        }}
+      >
+        <FlexWidget
+          style={{
+            flex: 1,
+            height: 1,
+            backgroundColor: w.gold25,
+          }}
+        />
+        <TextWidget
+          text="BUILDER"
+          style={{
+            fontSize: 7,
+            fontFamily: "DepartureMono",
+            color: w.mutedAmber,
+            letterSpacing: 2,
+          }}
+        />
+        <FlexWidget
+          style={{
+            flex: 1,
+            height: 1,
+            backgroundColor: w.gold25,
+          }}
+        />
+      </FlexWidget>
+
+      <FlexWidget style={{ height: 6 }} />
+
+      {/* Day count */}
+      <TextWidget
+        text={`DAY ${profile.dayCount}`}
+        style={{
+          fontSize: 13,
+          fontFamily: "DepartureMono",
+          fontWeight: "bold",
+          color: w.amber,
+          letterSpacing: 3,
+        }}
+      />
+    </FlexWidget>
+  );
+}

--- a/apps/mobile/src/widgets/ProjectsWidget.tsx
+++ b/apps/mobile/src/widgets/ProjectsWidget.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { FlexWidget, TextWidget, type ColorProp } from "react-native-android-widget";
+import { w } from "./theme";
+import type { WidgetProject } from "../lib/widget-data";
+
+function statusColor(status: string): ColorProp {
+  switch (status) {
+    case "idea":
+    case "looking_for_help":
+      return w.amberStatus;
+    case "in_progress":
+      return w.blue;
+    default:
+      return w.gray;
+  }
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "idea": return "Idea";
+    case "in_progress": return "In Progress";
+    case "looking_for_help": return "Help Wanted";
+    case "completed": return "Completed";
+    default: return status;
+  }
+}
+
+interface Props {
+  projects: WidgetProject[];
+  height: number;
+}
+
+export function ProjectsWidget({ projects, height }: Props) {
+  const maxItems = height > 200 ? 4 : 3;
+
+  return (
+    <FlexWidget
+      style={{
+        flexDirection: "column",
+        backgroundColor: w.pageBg,
+        borderRadius: 16,
+        padding: 14,
+        height: "match_parent" as any,
+        width: "match_parent" as any,
+      }}
+    >
+      {/* Header */}
+      <FlexWidget
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          width: "match_parent" as any,
+        }}
+      >
+        <TextWidget
+          text="PROJECTS"
+          style={{
+            fontSize: 11,
+            fontFamily: "DepartureMono",
+            color: w.amber,
+          }}
+        />
+        <TextWidget
+          text="All ▸"
+          clickAction="OPEN_APP"
+          clickActionData={{ screen: "(tabs)/projects" }}
+          style={{
+            fontSize: 10,
+            fontFamily: "DepartureMono",
+            color: w.gray,
+          }}
+        />
+      </FlexWidget>
+
+      <FlexWidget style={{ height: 8 }} />
+
+      {projects.length === 0 ? (
+        <FlexWidget
+          style={{
+            flex: 1,
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <TextWidget
+            text="No active projects"
+            style={{ fontSize: 12, fontFamily: "DepartureMono", color: w.gray }}
+          />
+        </FlexWidget>
+      ) : (
+        projects.slice(0, maxItems).map((project) => (
+          <FlexWidget
+            key={project.id}
+            clickAction="OPEN_APP"
+            clickActionData={{ screen: `(tabs)/projects/${project.id}` }}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              width: "match_parent" as any,
+              padding: 4,
+              flexGap: 8,
+            }}
+          >
+            {/* Status dot */}
+            <FlexWidget
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: 1,
+                backgroundColor: statusColor(project.status),
+              }}
+            />
+            {/* Title */}
+            <FlexWidget style={{ flex: 1 }}>
+              <TextWidget
+                text={project.title}
+                maxLines={1}
+                style={{ fontSize: 13, color: w.white }}
+              />
+            </FlexWidget>
+            {/* Status */}
+            <TextWidget
+              text={statusLabel(project.status)}
+              style={{
+                fontSize: 10,
+                fontFamily: "DepartureMono",
+                color: statusColor(project.status),
+              }}
+            />
+          </FlexWidget>
+        ))
+      )}
+    </FlexWidget>
+  );
+}

--- a/apps/mobile/src/widgets/QuickActionsWidget.tsx
+++ b/apps/mobile/src/widgets/QuickActionsWidget.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { FlexWidget, TextWidget } from "react-native-android-widget";
+import { w } from "./theme";
+
+export function QuickActionsWidget() {
+  return (
+    <FlexWidget
+      style={{
+        flexDirection: "column",
+        backgroundColor: w.pageBg,
+        borderRadius: 16,
+        padding: 14,
+        height: "match_parent" as any,
+        width: "match_parent" as any,
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {/* Logo */}
+      <TextWidget
+        text="N3Q"
+        style={{
+          fontSize: 13,
+          fontFamily: "DepartureMono",
+          fontWeight: "bold",
+          color: w.amber,
+          letterSpacing: 2,
+        }}
+      />
+
+      <FlexWidget style={{ height: 12 }} />
+
+      {/* Action buttons row */}
+      <FlexWidget
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-evenly",
+          width: "match_parent" as any,
+        }}
+      >
+        <FlexWidget
+          clickAction="OPEN_APP"
+          clickActionData={{ screen: "(tabs)/feed/add" }}
+          style={{
+            flexDirection: "column",
+            alignItems: "center",
+            flexGap: 4,
+          }}
+        >
+          <TextWidget
+            text="📖"
+            style={{ fontSize: 20 }}
+          />
+          <TextWidget
+            text="Post"
+            style={{ fontSize: 9, fontFamily: "DepartureMono", color: w.gray }}
+          />
+        </FlexWidget>
+
+        <FlexWidget
+          clickAction="OPEN_APP"
+          clickActionData={{ screen: "(tabs)/events/create" }}
+          style={{
+            flexDirection: "column",
+            alignItems: "center",
+            flexGap: 4,
+          }}
+        >
+          <TextWidget
+            text="📅"
+            style={{ fontSize: 20 }}
+          />
+          <TextWidget
+            text="Event"
+            style={{ fontSize: 9, fontFamily: "DepartureMono", color: w.gray }}
+          />
+        </FlexWidget>
+
+        <FlexWidget
+          clickAction="OPEN_APP"
+          clickActionData={{ screen: "(tabs)/projects/create" }}
+          style={{
+            flexDirection: "column",
+            alignItems: "center",
+            flexGap: 4,
+          }}
+        >
+          <TextWidget
+            text="🚀"
+            style={{ fontSize: 20 }}
+          />
+          <TextWidget
+            text="Project"
+            style={{ fontSize: 9, fontFamily: "DepartureMono", color: w.gray }}
+          />
+        </FlexWidget>
+      </FlexWidget>
+    </FlexWidget>
+  );
+}

--- a/apps/mobile/src/widgets/handler.tsx
+++ b/apps/mobile/src/widgets/handler.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { WidgetTaskHandlerProps } from "react-native-android-widget";
+import { EventsWidget } from "./EventsWidget";
+import { ProjectsWidget } from "./ProjectsWidget";
+import { QuickActionsWidget } from "./QuickActionsWidget";
+import { MemberCardWidget } from "./MemberCardWidget";
+import { BrandWidget } from "./BrandWidget";
+import type { WidgetEvent, WidgetProject, WidgetProfile } from "../lib/widget-data";
+
+// Widget data is stored in AsyncStorage with these keys
+// (written by the same updateWidget* functions that write to iOS UserDefaults)
+const STORAGE_KEYS = {
+  events: "widget_events_android",
+  projects: "widget_projects_android",
+  profile: "widget_profile_android",
+};
+
+async function loadEvents(): Promise<WidgetEvent[]> {
+  try {
+    const data = await AsyncStorage.getItem(STORAGE_KEYS.events);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function loadProjects(): Promise<WidgetProject[]> {
+  try {
+    const data = await AsyncStorage.getItem(STORAGE_KEYS.projects);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function loadProfile(): Promise<WidgetProfile | null> {
+  try {
+    const data = await AsyncStorage.getItem(STORAGE_KEYS.profile);
+    return data ? JSON.parse(data) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
+  const { widgetInfo, widgetAction, renderWidget, clickAction, clickActionData } = props;
+
+  // Handle click actions — open the app to a specific screen
+  if (widgetAction === "WIDGET_CLICK" && clickAction === "OPEN_APP") {
+    // The app will handle deep linking via the clickActionData.screen value
+    // when the headless task launches the app
+    return;
+  }
+
+  if (widgetAction === "WIDGET_DELETED") return;
+
+  const { widgetName, width, height } = widgetInfo;
+
+  switch (widgetName) {
+    case "EventsWidget": {
+      const events = await loadEvents();
+      renderWidget(<EventsWidget events={events} width={width} height={height} />);
+      break;
+    }
+    case "ProjectsWidget": {
+      const projects = await loadProjects();
+      renderWidget(<ProjectsWidget projects={projects} height={height} />);
+      break;
+    }
+    case "QuickActionsWidget": {
+      renderWidget(<QuickActionsWidget />);
+      break;
+    }
+    case "MemberCardWidget": {
+      const profile = await loadProfile();
+      renderWidget(<MemberCardWidget profile={profile} />);
+      break;
+    }
+    case "BrandWidget": {
+      renderWidget(<BrandWidget width={width} />);
+      break;
+    }
+  }
+}
+
+export { STORAGE_KEYS };

--- a/apps/mobile/src/widgets/theme.ts
+++ b/apps/mobile/src/widgets/theme.ts
@@ -1,0 +1,25 @@
+// Widget color palette — matches trading card aesthetic
+// Android widget colors must be #hex or rgba(r, g, b, a) with spaces
+export const w = {
+  // Backgrounds
+  pageBg: "#0a0a0a",
+  cardBg: "#1a1610",
+  cardBgDark: "#0f0d0a",
+  parchment: "#2c2418",
+
+  // Gold/amber accents
+  amber: "#d4a84b",
+  amberDim: "#c89b37",
+  gold50: "rgba(180, 130, 50, 0.5)" as const,
+  gold25: "rgba(180, 130, 50, 0.25)" as const,
+  gold60: "rgba(200, 155, 55, 0.6)" as const,
+
+  // Text
+  white: "#fafafa",
+  gray: "#a1a1a1",
+  mutedAmber: "rgba(200, 155, 55, 0.4)" as const,
+
+  // Status colors
+  amberStatus: "#f5a623",
+  blue: "#62a5fa",
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
+      react-native-android-widget:
+        specifier: ^0.20.1
+        version: 0.20.1(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       react-native-gesture-handler:
         specifier: ~2.28.0
         version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
@@ -5735,6 +5738,16 @@ packages:
 
   react-is@19.2.4:
     resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
+
+  react-native-android-widget@0.20.1:
+    resolution: {integrity: sha512-m3akQCyoG6XUH8OLHOyL3/Xxx/XXTXf9ZyFYmWvSQrv1YUaZ7kVjmeLIYnaNz+qQ9VrTAS9OygCxZQptqCGzjQ==}
+    peerDependencies:
+      expo: '>=54.0.0'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
 
   react-native-gesture-handler@2.28.0:
     resolution: {integrity: sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==}
@@ -14723,6 +14736,13 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.4: {}
+
+  react-native-android-widget@0.20.1(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10)
 
   react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds 5 Android home screen widgets matching the iOS widget set
- Uses `react-native-android-widget` with Expo config plugin for native code generation
- Widget UI defined in React Native JSX (not raw Kotlin/XML)
- Unified `widget-data.ts` handles both iOS (UserDefaults) and Android (AsyncStorage)
- Profile data pushed to widgets on login, cleared on sign out

## Widgets

| Widget | Size | Description |
|--------|------|-------------|
| Events | 4x2 | Upcoming events with date/time, deep links to event detail |
| Projects | 4x2 | Active projects with status indicators |
| Quick Actions | 2x2 | Post, Event, Project shortcut buttons |
| Member Card | 2x2 | Trading card style: initials, name, day counter |
| Brand | 2x2 | N3Q logo + "A lab for builders, backed by unicorn founders" |

## Technical

- `react-native-android-widget` generates `AppWidgetProvider` Java classes + XML via Expo config plugin
- DepartureMono font included in widget rendering
- Task handler in `src/widgets/handler.tsx` renders widget JSX on demand
- Entry point changed from `expo-router/entry` to `./index.ts` to register widget task handler

## Test plan

- [ ] `npx expo prebuild --platform android --clean` succeeds
- [ ] Android build compiles with widget providers
- [ ] Widgets appear in Android home screen widget picker
- [ ] Member Card shows profile data after login
- [ ] Events/Projects widgets show data from app

🤖 Generated with [Claude Code](https://claude.com/claude-code)